### PR TITLE
Use `fire-native-event` for emitting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 var synth = require('synthetic-dom-events');
+var fireNative = require('fire-native-event');
 
 var on = function(element, name, fn, capture) {
     return element.addEventListener(name, fn, capture || false);
@@ -19,7 +20,7 @@ var once = function (element, name, fn, capture) {
 
 var emit = function(element, name, opt) {
     var ev = synth(name, opt);
-    element.dispatchEvent(ev);
+    fireNative(element, ev);
 };
 
 if (!document.addEventListener) {
@@ -31,13 +32,6 @@ if (!document.addEventListener) {
 if (!document.removeEventListener) {
     off = function(element, name, fn) {
         return element.detachEvent('on' + name, fn);
-    };
-}
-
-if (!document.dispatchEvent) {
-    emit = function(element, name, opt) {
-        var ev = synth(name, opt);
-        return element.fireEvent('on' + ev.type, ev);
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "dom event binding and triggering",
   "main": "index.js",
   "dependencies": {
+    "fire-native-event": "^2.0.0",
     "synthetic-dom-events": "0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Thank you for dom-events, Roman.

I made this [fire-native-event module](https://github.com/mightyiam/fire-native-event) and for the sake of modularity, I'm posting this PR.

I think that the JS codesphere can and should consist of more tightly scoped modules.

I've tested it in IE8-11 and latest Chromium and Firefox.
